### PR TITLE
02_modesetting: fix byte order in ARGB example

### DIFF
--- a/02_modesetting/02_modesetting.md
+++ b/02_modesetting/02_modesetting.md
@@ -103,7 +103,7 @@ using `ARGB8888` and wanted write the colour
 [#112233](http://www.color-hex.com/color/112233)[100], in memory, it would look
 like
 ```c
-uint8_t pixel[4] = { 0xff, 0x33, 0x22, 0x11 };
+uint8_t pixel[4] = { 0x33, 0x22, 0x11, 0xFF };
 ```
 
 ## CRTCs


### PR DESCRIPTION
This is about endianness, so this going to be confusing.

We want to express the colour #112233, ie. R=0x11, G=0x22, B=0x33,
A=0xFF.

The DRM format we use is ARGB8888, which means: A at the highest
address, then R, G, then B at the lowest address. This gives us:

    uint32_t argb = 0xFF112233;
    //                ^ highest address
    //       lowest address ^

Then we need to convert to the memory layout, little endian inverts the
order:

    uint8_t pixel[4] = { 0x33, 0x22, 0x11, 0xFF };
    //                   ^ lowest address
    //                     highest address ^

See also: https://afrantzis.com/pixel-format-guide/drm.html